### PR TITLE
simulator: don't treat dial errors as errors

### DIFF
--- a/simulator/miner.go
+++ b/simulator/miner.go
@@ -44,8 +44,7 @@ func (s *StratumMiner) Simulate(ctx context.Context, dst string) error {
 		conn.Close()
 	}
 
-	// TODO Dropping isDialError() as an error as it's causing too many io-timeout messages.
-	if isSoftError(err, "connect: connection refused") || isDialError(err) {
+	if isSoftError(err, "connect: connection refused") {
 		return nil
 	}
 	return err

--- a/simulator/tunnel-dns.go
+++ b/simulator/tunnel-dns.go
@@ -56,8 +56,8 @@ func (s *Tunnel) Simulate(ctx context.Context, host string) error {
 		defer cancelFn()
 		_, err := r.LookupTXT(ctx, fmt.Sprintf("%s.%s", label, host))
 
-		// Ignore "no such host".  Will ignore timeouts as well, so check for dial errors.
-		if err != nil && !isSoftError(err, "no such host") && !isDialError(err) {
+		// Ignore "no such host".  Will ignore timeouts as well.
+		if err != nil && !isSoftError(err, "no such host") {
 			return err
 		}
 


### PR DESCRIPTION
Leads to too many superfluous io-timeout messages.