### PR TITLE
cmd/run: detect simulation errors and exit with appropriate rc

### DIFF
--- a/cmd/run/print.go
+++ b/cmd/run/print.go
@@ -30,6 +30,11 @@ The current time is %s
 `, Version, ip, dnsIntfIP, time.Now().Format("02-Jan-06 15:04:05"))
 }
 
-func printGoodbye() {
-	fmt.Printf("\nAll done! Check your SIEM for alerts using the timestamps and details above.\n")
+func printGoodbye(simErrsDetected bool) {
+	if simErrsDetected {
+		fmt.Printf("\nAll done, but simulation errors occurred! ")
+	} else {
+		fmt.Printf("\nAll done! ")
+	}
+	fmt.Printf("Check your SIEM for alerts using the timestamps and details above.\n")
 }

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -358,6 +359,22 @@ func getDefaultDNSIntf() (string, error) {
 	return dnsIntfIP, nil
 }
 
+// failedSimulationNames returns a sorted slice of failed simulation names extracted from
+// them sims map.
+func failedSimulationNames(sims map[string]bool) []string {
+	if len(sims) == 0 {
+		return nil
+	}
+	failedSims := make([]string, len(sims))
+	i := 0
+	for sim := range sims {
+		failedSims[i] = sim
+		i++
+	}
+	sort.Strings(failedSims)
+	return failedSims
+}
+
 func run(sims []*Simulation, bind simulator.BindAddr, size int) error {
 	// If user override on iface, both IP and DNS traffic will flow through bind.Addr.
 	// NOTE: not passing the DNS server to printWelcome(), as it may be confusing in cases
@@ -374,12 +391,15 @@ func run(sims []*Simulation, bind simulator.BindAddr, size int) error {
 	}
 	printHeader()
 
+	// Log failed simulations.
+	failedSims := make(map[string]bool)
 	for simN, sim := range sims {
 		fmt.Print("\n")
 
 		okHosts := 0
 		err := sim.Init(bind)
 		if err != nil {
+			failedSims[sim.Name()] = true
 			printMsg(sim, msgPrefixErrorInit+fmt.Sprint(err))
 		} else {
 			printMsg(sim, sim.HeaderMsg)
@@ -391,6 +411,7 @@ func run(sims []*Simulation, bind simulator.BindAddr, size int) error {
 
 			hosts, err := sim.Module.Hosts(sim.Scope, numOfHosts)
 			if err != nil {
+				failedSims[sim.Name()] = true
 				printMsg(sim, msgPrefixErrorInit+err.Error())
 				continue
 			}
@@ -412,6 +433,7 @@ func run(sims []*Simulation, bind simulator.BindAddr, size int) error {
 							// TODO: some module can return custom messages (e.g. hijack)
 							// and "ERROR" prefix shouldn't be printed then
 							printMsg(sim, fmt.Sprintf("ERROR: %s: %s", host, err.Error()))
+							failedSims[sim.Name()] = true
 						} else {
 							okHosts++
 						}
@@ -436,7 +458,14 @@ func run(sims []*Simulation, bind simulator.BindAddr, size int) error {
 		}
 		sim.Cleanup()
 	}
-
-	printGoodbye()
+	// Extract list of failed simulations and return as an error.
+	failedSimNames := failedSimulationNames(failedSims)
+	printGoodbye(failedSimNames != nil)
+	if failedSimNames != nil {
+		msg := fmt.Sprintf(
+			"The following simulations experienced errors: %v",
+			strings.Join(failedSimNames, ", "))
+		return errors.New(msg)
+	}
 	return nil
 }


### PR DESCRIPTION
Something along these lines:

```
$ ./flightsim run imposter
[...]
05:54:16 [imposter] Done (5/5)

All done! Check your SIEM for alerts using the timestamps and details above.
$ echo $?
0


$ ./flightsim run -iface lo0 imposter
[...]
05:54:21 [imposter] Resolving random imposter domains
05:54:22 [imposter] Resolving office365.com-edge2-cdn.net
05:54:22 [imposter] ERROR: office365.com-edge2-cdn.net: lookup office365.com-edge2-cdn.net. on 192.168.1.1:53: write udp 127.0.0.1:54473->192.168.1.1:53: write: can't assign requested address
[...]
05:54:26 [imposter] Done (0/5)

All done, but simulation errors ocurred! Check your SIEM for alerts using the timestamps and details above.
The following simulations experienced errors: imposter
$ echo $?
1


$ ./flightsim run imposter
[...]
06:08:53 [imposter] Resolving random imposter domains
06:08:54 [imposter] Resolving office365.com-edge2-cdn.net
06:08:54 [imposter] ERROR: office365.com-edge2-cdn.net: TEST ERROR
[...]
06:08:58 [imposter] Done (4/5)

All done, but simulation errors ocurred! Check your SIEM for alerts using the timestamps and details above.
The following simulations experienced errors: imposter
$ echo $?
1


$ ./flightsim run -iface lo0 tunnel-icmp
[...]
06:02:40 [tunnel-icmp] FATAL: Couldn't start the module: listen ip4:icmp 127.0.0.1: socket: operation not permitted (make sure you have sufficient network privileges or try to run as root)

All done, but simulation errors ocurred! Check your SIEM for alerts using the timestamps and details above.
The following simulations experienced errors: tunnel-icmp
$ echo $?
1


$ ./flightsim run -iface lo0 -fast
[...]

All done, but simulation errors ocurred! Check your SIEM for alerts using the timestamps and details above.
The following simulations experienced errors: c2, dga, imposter, miner, scan, sink, spambot, ssh-exfil, ssh-transfer, tunnel-dns, tunnel-icmp
$ echo $?
1
```

